### PR TITLE
Fixing bug that causes unnecessary re-mount

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ComponentType, createElement, forwardRef, lazy, memo } from "react";
+import { ComponentType, createElement, forwardRef, lazy, useRef } from "react";
 
 export type PreloadableComponent<T extends ComponentType<any>> = T & {
     preload: () => Promise<T>;
@@ -7,24 +7,30 @@ export type PreloadableComponent<T extends ComponentType<any>> = T & {
 export function lazyWithPreload<T extends ComponentType<any>>(
     factory: () => Promise<{ default: T }>
 ): PreloadableComponent<T> {
-    const LazyComponent = lazy(factory);
+    const ReactLazyComponent = lazy(factory);
+    let PreloadedComponent: T | undefined;
     let factoryPromise: Promise<T> | undefined;
-    let LoadedComponent: T | undefined;
 
     const Component = forwardRef(function LazyWithPreload(props, ref) {
+        // Once one of these is chosen, we must ensure that it continues to be
+        // used for all subsequent renders, otherwise it can cause the
+        // underlying component to be unmounted and remounted.
+        const ComponentToRender = useRef(
+            PreloadedComponent ?? ReactLazyComponent
+        );
         return createElement(
-            LoadedComponent ?? LazyComponent,
+            ComponentToRender.current,
             Object.assign(ref ? { ref } : {}, props) as any
         );
     });
 
-    const LazyWithPreload = memo(Component) as any as PreloadableComponent<T>;
+    const LazyWithPreload = Component as any as PreloadableComponent<T>;
 
     LazyWithPreload.preload = () => {
         if (!factoryPromise) {
             factoryPromise = factory().then((module) => {
-                LoadedComponent = module.default;
-                return LoadedComponent;
+                PreloadedComponent = module.default;
+                return PreloadedComponent;
             });
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ComponentType, createElement, forwardRef, lazy } from "react";
+import { ComponentType, createElement, forwardRef, lazy, memo } from "react";
 
 export type PreloadableComponent<T extends ComponentType<any>> = T & {
     preload: () => Promise<T>;
@@ -16,9 +16,11 @@ export function lazyWithPreload<T extends ComponentType<any>>(
             LoadedComponent ?? LazyComponent,
             Object.assign(ref ? { ref } : {}, props) as any
         );
-    }) as any as PreloadableComponent<T>;
+    });
 
-    Component.preload = () => {
+    const LazyWithPreload = memo(Component) as any as PreloadableComponent<T>;
+
+    LazyWithPreload.preload = () => {
         if (!factoryPromise) {
             factoryPromise = factory().then((module) => {
                 LoadedComponent = module.default;
@@ -29,7 +31,7 @@ export function lazyWithPreload<T extends ComponentType<any>>(
         return factoryPromise;
     };
 
-    return Component;
+    return LazyWithPreload;
 }
 
 export default lazyWithPreload;


### PR DESCRIPTION
This would occur if the component was rendered prior to invoking preload(), or prior to its promise being fully resolved.

See discussion in [this PR](https://github.com/ianschmitz/react-lazy-with-preload/pull/20) for more info.